### PR TITLE
feat: add support for TypedDocumentNode

### DIFF
--- a/.changeset/few-peas-turn.md
+++ b/.changeset/few-peas-turn.md
@@ -1,0 +1,5 @@
+---
+'rivet-graphql': minor
+---
+
+Add support for TypedDocumentNode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,5 +35,5 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
-      - name: Run type check
+      - name: Run tests
         run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .DS_Store
 index.d.ts
 index.d.ts.map
+index.js

--- a/index.test.js
+++ b/index.test.js
@@ -147,7 +147,6 @@ test('handles the "components" parameter correctly', async () => {
     wow
   }
 }
-
 fragment c1 on Test { test }
 fragment d1 on Test { test }
 fragment d2 on Test { test }
@@ -212,7 +211,7 @@ test('still throws if all retries fail', () => {
   })
     .catch((err) => {
       expect(err.toString()).toEqual(
-        'Error: GraphQL Error (Code: 500): {"response":{"data":"test","status":500},"request":{"query":"test\\n"}}'
+        'Error: GraphQL Error (Code: 500): {"response":{"data":"test","status":500,"headers":{}},"request":{"query":"test\\n"}}'
       )
     })
     .finally(() => promisify(server.close.bind(server))())
@@ -239,7 +238,6 @@ test('allows GraphQL DocumentNode queries', () => {
     wow
   }
 }
-
 `)
   })
 })
@@ -262,7 +260,6 @@ test('allows GraphQL DocumentNode queries with dependencies', () => {
     wow
   }
 }
-
 fragment test on Test { test }`)
   })
 })
@@ -287,11 +284,9 @@ test('allows GraphQL DocumentNode queries with DocumentNode dependencies', () =>
     wow
   }
 }
-
 fragment test on Test {
   test
-}
-`)
+}`)
   })
 })
 
@@ -327,7 +322,7 @@ function testFetchMock(params, cb) {
   }
 
   rivet.__with__(
-    'GraphQLClient',
+    'graphql_request_1.GraphQLClient',
     MockGraphQLClient
   )(() => {
     return createTestInstance()(params)

--- a/index.ts
+++ b/index.ts
@@ -44,7 +44,7 @@ export = function Rivet(
     query: string | DocumentNode | TypedDocumentNode<T, V>
     dependencies?: { fragmentSpec?: FragmentSpec }[]
     variables?: Record<string, unknown>
-  }): Promise<V> {
+  }): Promise<T> {
     if (!query) throw fetchMissingQueryError()
 
     const _dependencies = processDependencies(dependencies)

--- a/index.ts
+++ b/index.ts
@@ -36,7 +36,7 @@ export = function Rivet(
     )
   }
 
-  function fetch<T, V extends Variables = Variables>({
+  function fetch<T = any, V extends Variables = Variables>({
     query,
     dependencies = [],
     variables,

--- a/index.ts
+++ b/index.ts
@@ -3,28 +3,25 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-//@ts-check
-let { GraphQLClient } = require('graphql-request')
-const { parse, parseType } = require('graphql/language/parser')
-const { print } = require('graphql/language/printer')
+import { GraphQLClient, type Variables } from 'graphql-request'
+import { parse, parseType } from 'graphql/language/parser'
+import { print } from 'graphql/language/printer'
+import type { DocumentNode } from 'graphql'
+import type { TypedDocumentNode } from '@graphql-typed-document-node/core'
 
-/** @typedef { import("graphql-request/dist/types.dom").RequestInit} GQLRequestInit */
-/** @typedef { import("graphql/language/ast").DocumentNode} DocumentNode */
-/** @typedef { import("graphql-request").GraphQLClient } */
+interface FragmentSpec {
+  fragment?: string | DocumentNode
+  dependencies?: { fragmentSpec?: FragmentSpec }[]
+  requiredVariables?: Record<string, unknown>
+}
 
-/**
- * @typedef {Object} FragmentSpec
- * @property {string | DocumentNode} [fragment]
- * @property {{ fragmentSpec?: FragmentSpec }[]} [dependencies]
- * @property {Record<string, any>} [requiredVariables]
- */
-
-/**
- *
- * @param {string} url
- * @param {GQLRequestInit & { timeout?: number, retryCount?: number }} options
- */
-module.exports = function Rivet(url, options) {
+export = function Rivet(
+  url: string,
+  options: ConstructorParameters<typeof GraphQLClient>[1] & {
+    timeout?: number
+    retryCount?: number
+  }
+) {
   if (!options.timeout) options.timeout = 30000
   const retryCount = options.retryCount || 0
   delete options.retryCount
@@ -39,16 +36,15 @@ module.exports = function Rivet(url, options) {
     )
   }
 
-  /**
-   *
-   * @template [T=any]
-   * @param {Object} params
-   * @param {string | DocumentNode} params.query
-   * @param {{ fragmentSpec?: FragmentSpec }[]} [params.dependencies]
-   * @param {Record<string, any>} [params.variables]
-   * @returns {Promise<T>}
-   */
-  function fetch({ query, dependencies = [], variables }) {
+  function fetch<T, V extends Variables = Variables>({
+    query,
+    dependencies = [],
+    variables,
+  }: {
+    query: string | DocumentNode | TypedDocumentNode<T, V>
+    dependencies?: { fragmentSpec?: FragmentSpec }[]
+    variables?: Record<string, unknown>
+  }): Promise<V> {
     if (!query) throw fetchMissingQueryError()
 
     const _dependencies = processDependencies(dependencies)
@@ -143,7 +139,7 @@ function processVariables(dependencies, variables, query) {
       kind: 'Variable',
       name: { kind: 'Name', value: _name },
     }
-    const type = parseType(_type)
+    const type = parseType(_type as any)
 
     // Add the AST nodes to the variable definitions at the top of the query.
     // Worth noting it only does this for the first query defined in the file,
@@ -174,7 +170,7 @@ function _findVariables(_dependencies, variables) {
   return dependencies.reduce((acc, component) => {
     if (component.requiredVariables) {
       // If no variables are passed to fetch but dependencies define variables, error
-      if (!variables) throw variableMismatchError(component)
+      if (!variables) throw variableMismatchError(component, null)
 
       Object.entries(component.requiredVariables).map(([k, v]) => {
         // If variables are present but the one we need is missing, error

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,24 @@
 {
   "name": "rivet-graphql",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rivet-graphql",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "graphql": "^15.3.0",
-        "graphql-request": "^3.0.0"
+        "@graphql-typed-document-node/core": "^3.1.2",
+        "graphql": "^16.6.0",
+        "graphql-request": "^5.2.0"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",
         "@changesets/cli": "^2.26.0",
         "jest": "^26.4.2",
         "rewire": "^5.0.0",
-        "typescript": "^4.6.2"
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1141,6 +1142,14 @@
         "node": ">=0.1.95"
       }
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.2.tgz",
+      "integrity": "sha512-9anpBMM9mEgZN4wr2v8wHJI2/u5TnnggewRN6OlvXTTnuVyoY19X6rOv9XTqKRw6dcGKwZsBi8n0kDE2I5i4VA==",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -1923,8 +1932,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -2445,7 +2453,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2490,11 +2497,11 @@
       "dev": true
     },
     "node_modules/cross-fetch": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.5.tgz",
-      "integrity": "sha512-FFLcLtraisj5eteosnX1gf01qYDCOc4fDy0+euOt8Kn9YBY2NtXL/pCoYPavw24NIQkQqm5ZOLsGD5Zzj0gyew==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
       "dependencies": {
-        "node-fetch": "2.6.0"
+        "node-fetch": "2.6.7"
       }
     },
     "node_modules/cross-spawn": {
@@ -2777,7 +2784,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3569,6 +3575,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+      "engines": {
+        "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -4034,25 +4051,38 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
-      "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.6.0.tgz",
+      "integrity": "sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==",
       "engines": {
-        "node": ">= 10.x"
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
     },
     "node_modules/graphql-request": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.0.0.tgz",
-      "integrity": "sha512-zW8AuLnKMYOnpVKdANU9FzLDoj4u4AoU6KZ79e+BcJaNiuw/vgCJ0p7ppDMSDrW77a12Moa7J7Mg4w0f9Kd/Kg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.2.0.tgz",
+      "integrity": "sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==",
       "dependencies": {
-        "cross-fetch": "^3.0.4"
-      },
-      "engines": {
-        "node": "10.x || 12.x || 14.x"
+        "@graphql-typed-document-node/core": "^3.1.1",
+        "cross-fetch": "^3.1.5",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
       },
       "peerDependencies": {
-        "graphql": "14.x || 15.x"
+        "graphql": "14 - 16"
+      }
+    },
+    "node_modules/graphql-request/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/growly": {
@@ -6019,7 +6049,6 @@
       "version": "1.44.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
       "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6028,7 +6057,6 @@
       "version": "2.1.27",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
       "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.44.0"
       },
@@ -6179,11 +6207,41 @@
       "dev": true
     },
     "node_modules/node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -8595,9 +8653,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.2",
         "graphql": "^16.6.0",
-        "graphql-request": "^5.2.0"
+        "graphql-request": "~5.1.0"
       },
       "devDependencies": {
         "@changesets/changelog-github": "^0.4.8",
@@ -4059,9 +4059,9 @@
       }
     },
     "node_modules/graphql-request": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.2.0.tgz",
-      "integrity": "sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-5.1.0.tgz",
+      "integrity": "sha512-0OeRVYigVwIiXhNmqnPDt+JhMzsjinxHE7TVy3Lm6jUzav0guVcL0lfSbi6jVTRAxcbwgyr6yrZioSHxf9gHzw==",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "cross-fetch": "^3.1.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "@graphql-typed-document-node/core": "^3.1.2",
     "graphql": "^16.6.0",
-    "graphql-request": "^5.2.0"
+    "graphql-request": "~5.1.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",

--- a/package.json
+++ b/package.json
@@ -7,15 +7,16 @@
     "url": "https://github.com/hashicorp/rivet-graphql/issues"
   },
   "dependencies": {
-    "graphql": "^15.3.0",
-    "graphql-request": "^3.0.0"
+    "@graphql-typed-document-node/core": "^3.1.2",
+    "graphql": "^16.6.0",
+    "graphql-request": "^5.2.0"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",
     "@changesets/cli": "^2.26.0",
     "jest": "^26.4.2",
     "rewire": "^5.0.0",
-    "typescript": "^4.6.2"
+    "typescript": "^4.9.5"
   },
   "homepage": "https://github.com/hashicorp/rivet-graphql#readme",
   "keywords": [
@@ -34,7 +35,7 @@
   "scripts": {
     "release": "npm run generate:types && changeset publish",
     "release:canary": "npm run generate:types && changeset publish --tag canary",
-    "test": "jest",
+    "test": "npm run generate:types && jest",
     "generate:types": "tsc -p ."
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,11 @@
 {
   "compilerOptions": {
+    "target": "es2020",
     "lib": ["es2020"],
     "module": "commonjs",
-    "allowJs": true,
     "declaration": true,
-    "emitDeclarationOnly": true,
-    "declarationMap": true,
     "downlevelIteration": true,
     "skipLibCheck": true
   },
-  "include": ["index.js"]
+  "include": ["index.ts"]
 }


### PR DESCRIPTION
This PR adds support for [`TypedDocumentNode`](https://github.com/dotansimha/graphql-typed-document-node) in addition to migrating the library to TypeScript.